### PR TITLE
Fix syntax in agent parameters

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -78,7 +78,6 @@ class Agent:
         message_params overriding conflicting keys.
         """
         params = {
-        params = {
             "model": self.config.model,
             "max_tokens": self.config.max_tokens,
             "temperature": self.config.temperature,


### PR DESCRIPTION
## Summary
- fix syntax error in agents/agent.py

## Testing
- `pytest tests/test_cli.py -q` *(fails: Interaction Error, ModelValidation)*

------
https://chatgpt.com/codex/tasks/task_e_68774c268ad4832ca2102f120ce2c66c