### PR TITLE
Fix insecure iframe URLs

### DIFF
--- a/computer-use-demo/image/index.html
+++ b/computer-use-demo/image/index.html
@@ -29,12 +29,12 @@
     <body>
         <div class="container">
             <iframe
-                src="http://localhost:8501"
+                src="https://localhost:8501"
                 class="left"
                 allow="fullscreen"
             ></iframe>
             <iframe
-                src="http://localhost:6080/vnc.html?view_only=1&autoconnect=1&resize=scale"
+                src="https://localhost:6080/vnc.html?view_only=1&autoconnect=1&resize=scale"
                 class="right"
                 allow="fullscreen"
             ></iframe>

--- a/computer-use-demo/image/static_content/index.html
+++ b/computer-use-demo/image/static_content/index.html
@@ -29,13 +29,13 @@
     <body>
         <div class="container">
             <iframe
-                src="http://localhost:8501"
+                src="https://localhost:8501"
                 class="left"
                 allow="fullscreen"
             ></iframe>
             <iframe
                 id="vnc"
-                src="http://127.0.0.1:6080/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000"
+                src="https://127.0.0.1:6080/vnc.html?&resize=scale&autoconnect=1&view_only=1&reconnect=1&reconnect_delay=2000"
                 class="right"
                 allow="fullscreen"
             ></iframe>


### PR DESCRIPTION
## Summary
- update demo index pages to load iframes over HTTPS

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'computer_use_demo')*
- `flake8` *(fails: lots of style errors)*

------
https://chatgpt.com/codex/tasks/task_e_687751f6538c832c8d2e8073de7bf566