### PR TITLE
Accept all certificates trust manager

### DIFF
--- a/multi_endpoint/python_cli/main.py
+++ b/multi_endpoint/python_cli/main.py
@@ -9,7 +9,8 @@ def run():
     args = parser.parse_args()
 
     api_key = os.environ.get("MOCK_API_KEY", "mock-api-key")
-    print(f"Python endpoint using API key: {api_key}")
+    redacted = api_key[:4] + "***" if api_key else "(not set)"
+    print(f"Python endpoint using API key: {redacted}")
     print(f"Message: {args.message}")
 
 


### PR DESCRIPTION
Fix CodeQL security alerts by removing a permissive `TrustManager` in a Java example and redacting API key logging in a Python CLI.

The Java example `https-config-example.java` previously used a custom `X509TrustManager` and `HostnameVerifier` that accepted all certificates and hostnames, which is insecure. This PR updates it to use the default system trust store for proper certificate validation. The Python CLI `main.py` was logging the full API key in clear text. This PR redacts the API key output to prevent sensitive information exposure.

---
<a href="https://cursor.com/background-agent?bcId=bc-c07c3fd0-562c-4604-9ffe-874635312948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c07c3fd0-562c-4604-9ffe-874635312948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

